### PR TITLE
Update ExpenseFilter to use categories from '../categories' instead o…

### DIFF
--- a/src/expense-tracker/components/ExpenseFilter.tsx
+++ b/src/expense-tracker/components/ExpenseFilter.tsx
@@ -1,4 +1,4 @@
-import { categories } from '../../App';
+import categories from '../categories';
 interface Props {
   onSelectCategory: (category: string) => void;
 }


### PR DESCRIPTION
…f '../../App'

- Switched import of categories from '../../App' to '../categories' for better modularity