### PR TITLE
fix: refactor error handling with try-catch block

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 
 interface User {
@@ -11,10 +11,19 @@ function App() {
   const [error, setError] = useState('');
 
   useEffect(() => {
-    axios
-      .get<User[]>('https://jsonplaceholder.typicode.com/users')
-      .then((res) => setUsers(res.data))
-      .catch((err) => setError(err.message));
+    const fetchUsers = async () => {
+      try {
+        const res = await axios.get<User[]>('https://jsonplaceholder.typicode.com/users');
+        setUsers(res.data);
+      } catch (err) {
+        setError((err as AxiosError).message);
+      }
+    };
+
+    fetchUsers();
+
+    // .then((res) => setUsers(res.data))
+    // .catch((err) => setError(err.message));
   }, []);
 
   return (


### PR DESCRIPTION
- Replaced `.then()` and `.catch()` with a `try-catch` block for better async error handling.
- Used `axios.get()` inside an async function and caught errors with `catch`.
- Commented out the `.then()` and `.catch()` approach to demonstrate alternative error handling method.