### PR TITLE
feat: Implement axios request cancellation using AbortController and …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import axios, { CanceledError } from 'axios';
 import { useEffect, useState } from 'react';
 
 interface User {
@@ -11,19 +11,16 @@ function App() {
   const [error, setError] = useState('');
 
   useEffect(() => {
-    const fetchUsers = async () => {
-      try {
-        const res = await axios.get<User[]>('https://jsonplaceholder.typicode.com/users');
-        setUsers(res.data);
-      } catch (err) {
-        setError((err as AxiosError).message);
-      }
-    };
+    const controller = new AbortController();
 
-    fetchUsers();
-
-    // .then((res) => setUsers(res.data))
-    // .catch((err) => setError(err.message));
+    axios
+      .get<User[]>('https://jsonplaceholder.typicode.com/users', { signal: controller.signal })
+      .then((res) => setUsers(res.data))
+      .catch((err) => {
+        if (err instanceof CanceledError) return;
+        setError(err.message);
+      });
+    return () => controller.abort();
   }, []);
 
   return (


### PR DESCRIPTION
### Summary

This PR implements request cancellation using `AbortController` in the `useEffect` hook for fetching user data with Axios. The following changes were made:

- Added `AbortController` to handle request cancellation.
- Used the `signal` property of `AbortController` with the Axios request to support cancellation.
- Managed the cancellation by checking if the error is an instance of `CanceledError` to prevent unnecessary state updates.
- Implemented a cleanup function within the `useEffect` to call `controller.abort()` when the component is unmounted.

### Why?

To prevent memory leaks or errors in case the component is unmounted before the request finishes, Axios requests can be aborted. This ensures that only valid data is set to the state.

### Changes

- Introduced `AbortController` to manage the cancellation of Axios requests.
- Ensured proper error handling by distinguishing between cancellation errors and other errors.


