### PR TITLE
Add loading state and spinner for data fetching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,23 +9,32 @@ interface User {
 function App() {
   const [users, setUsers] = useState<User[]>([]);
   const [error, setError] = useState('');
+  const [isLoading, setLoading] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
 
+    setLoading(true);
+
     axios
       .get<User[]>('https://jsonplaceholder.typicode.com/users', { signal: controller.signal })
-      .then((res) => setUsers(res.data))
+      .then((res) => {
+        setUsers(res.data);
+        setLoading(false);
+      })
       .catch((err) => {
         if (err instanceof CanceledError) return;
         setError(err.message);
+        setLoading(false);
       });
+
     return () => controller.abort();
   }, []);
 
   return (
     <>
       {error && <p className='text-danger'>{error}</p>}
+      {isLoading && <div className='spinner-border'></div>}
       <ul>
         {users.map((user) => (
           <li key={user.id}>{user.name}</li>


### PR DESCRIPTION

This PR introduces a loading state while fetching user data.  
I simulated a slow network using Chrome DevTools and **inserted a screenshot** to demonstrate the behavior.

## Changes Made
- Added `isLoading` state to track loading status.
- Displayed a spinner (`spinner-border`) when data is loading.
- Ensured loading state is reset on success and error responses.

## Code Snippet
```tsx
const [isLoading, setLoading] = useState(false);

useEffect(() => {
  const controller = new AbortController();
  setLoading(true);

  axios
    .get<User[]>('https://jsonplaceholder.typicode.com/users', { signal: controller.signal })
    .then((res) => {
      setUsers(res.data);
      setLoading(false);
    })
    .catch((err) => {
      if (err instanceof CanceledError) return;
      setError(err.message);
      setLoading(false);
    });

  return () => controller.abort();
}, []);
ion.